### PR TITLE
add secp256k1 recovery and message signing

### DIFF
--- a/tools/core/recovery.py
+++ b/tools/core/recovery.py
@@ -1,0 +1,67 @@
+# recoverable signatures and messagesigning stuff
+# Requires secp256k1 with a flag
+# ./configure --enable-module-recovery
+
+from . import secp256k1
+from binascii import b2a_base64, a2b_base64
+from hashlib import sha256
+from io import BytesIO
+
+def compact_encode(i:int) -> bytes:
+    """Encodes an integer as a compact int"""
+    if i < 0:
+        raise ValueError("integer can't be negative: {}".format(i))
+    order = 0
+    while (i>>(8*(2**order))):
+        order += 1
+    if order == 0:
+        if i < 0xfd:
+            return bytes([i])
+        order = 1
+    if order > 3:
+        raise ValueError("integer too large: {}".format(i))
+    return bytes([0xfc+order]) + i.to_bytes(2**order, 'little')
+
+def compact_decode(b:bytes) -> int:
+    """Converts bytes with compact int to int"""
+    stream = io.BytesIO(b)
+    i = stream.read(1)[0]
+    if i >= 0xfd:
+        bytes_to_read = 2**(i-0xfc)
+        return int.from_bytes(stream.read(bytes_to_read), 'little')
+    else:
+        return i
+
+def get_message_hash(msg: bytes) -> bytes:
+    """Sign message with private key"""
+    msghash = sha256(
+        sha256(
+            b'\x18Bitcoin Signed Message:\n' +
+            compact_encode(len(msg)) + msg
+        ).digest()
+    ).digest()
+    return msghash
+
+def sign_recoverable(msg: bytes, prv: bytes, compressed:bool=True) -> str:
+    msghash = get_message_hash(msg)
+    res = secp256k1.ecdsa_sign_recoverable(msghash, prv)
+    compact, flag = secp256k1.ecdsa_recoverable_signature_serialize_compact(res)
+    c = 4 if compressed else 0
+    first = bytes([27+flag+c])
+    ser = first + compact
+    return b2a_base64(ser).strip().decode()
+
+def recover_pubkey(b64sig, msg):
+    msghash = get_message_hash(msg)
+    res = a2b_base64(b64sig)
+    # convert first byte
+    first = res[0]-27
+    compressed = (first >= 4)
+    flag = first % 4
+    # compact signature
+    sig_compact = res[1:]
+    # secp signature
+    sig = secp256k1.ecdsa_recoverable_signature_parse_compact(sig_compact, flag)
+    # get pubkey
+    pub = secp256k1.ecdsa_recover(sig, msghash)
+    return pub

--- a/tools/core/recovery_test.py
+++ b/tools/core/recovery_test.py
@@ -1,0 +1,15 @@
+import pytest
+from .recovery import *
+
+def test_recovery():
+    # message hash to sign
+    msg = b"Hello world"
+    # private key to sign with
+    pk = b"1"*32
+    # get message signing
+    b64sig = sign_recoverable(msg, pk)
+    assert b64sig == "IKe84tb3CO7KPw7laQsh6Bjk0qNp5s1lId/iLcRBWmE1Nn8t6drArd1oiEkuPushNuDqQs8WB0kqxZ+MDmXBruQ="
+
+    # recover pubkey from b64sig
+    pub = recover_pubkey(b64sig, msg)
+    assert pub == secp256k1.ec_pubkey_create(pk)

--- a/tools/core/secp256k1.py
+++ b/tools/core/secp256k1.py
@@ -73,7 +73,23 @@ def _init(flags = (CONTEXT_SIGN | CONTEXT_VERIFY)):
 
     secp256k1.secp256k1_ec_pubkey_combine.argtypes = [c_void_p, c_char_p, c_void_p, c_size_t]
     secp256k1.secp256k1_ec_pubkey_combine.restype = c_int
-    
+
+    # recoverable module
+    secp256k1.secp256k1_ecdsa_sign_recoverable.argtypes = [c_void_p, c_char_p, c_char_p, c_char_p, c_void_p, c_void_p]
+    secp256k1.secp256k1_ecdsa_sign_recoverable.restype = c_int
+
+    secp256k1.secp256k1_ecdsa_recoverable_signature_parse_compact.argtypes = [c_void_p, c_char_p, c_char_p, c_int]
+    secp256k1.secp256k1_ecdsa_recoverable_signature_parse_compact.restype = c_int
+
+    secp256k1.secp256k1_ecdsa_recoverable_signature_serialize_compact.argtypes = [c_void_p, c_char_p, c_char_p, c_char_p]
+    secp256k1.secp256k1_ecdsa_recoverable_signature_serialize_compact.restype = c_int
+
+    secp256k1.secp256k1_ecdsa_recoverable_signature_convert.argtypes = [c_void_p, c_char_p, c_char_p]
+    secp256k1.secp256k1_ecdsa_recoverable_signature_convert.restype = c_int
+
+    secp256k1.secp256k1_ecdsa_recover.argtypes = [c_void_p, c_char_p, c_char_p, c_char_p]
+    secp256k1.secp256k1_ecdsa_recover.restype = c_int
+
     secp256k1.ctx = secp256k1.secp256k1_context_create(flags)
     
     r = secp256k1.secp256k1_context_randomize(secp256k1.ctx, os.urandom(32))
@@ -259,6 +275,57 @@ def ec_pubkey_combine(*args, context=_secp.ctx):
         raise ValueError("Failed to negate pubkey")
     return pub
 
+def ecdsa_sign_recoverable(msg, secret, context=_secp.ctx):
+    if len(msg)!=32:
+        raise ValueError("Message should be 32 bytes long")
+    if len(secret)!=32:
+        raise ValueError("Secret key should be 32 bytes long")
+    sig = bytes(65)
+    r = _secp.secp256k1_ecdsa_sign_recoverable(context, sig, msg, secret, None, None)
+    if r == 0:
+        raise ValueError("Failed to sign")
+    return sig
+
+def ecdsa_recoverable_signature_serialize_compact(sig, context=_secp.ctx):
+    if len(sig)!=65:
+        raise ValueError("Recoverable signature should be 65 bytes long")
+    ser = bytes(64)
+    idx = bytes(1)
+    r = _secp.secp256k1_ecdsa_recoverable_signature_serialize_compact(context, ser, idx, sig)
+    if r == 0:
+        raise ValueError("Failed serializing der signature")
+    return ser, idx[0]
+    
+def ecdsa_recoverable_signature_parse_compact(compact_sig, recid, context=_secp.ctx):
+    if len(compact_sig)!=64:
+        raise ValueError("Signature should be 64 bytes long")
+    sig = bytes(65)
+    r = _secp.secp256k1_ecdsa_recoverable_signature_parse_compact(context, sig, compact_sig, recid)
+    if r == 0:
+        raise ValueError("Failed parsing compact signature")
+    return sig
+
+def ecdsa_recoverable_signature_convert(sigin, context=_secp.ctx):
+    if len(compact_sig)!=65:
+        raise ValueError("Recoverable signature should be 65 bytes long")
+    sig = bytes(64)
+    r = _secp.secp256k1_ecdsa_recoverable_signature_convert(context, sig, sigin)
+    if r == 0:
+        raise ValueError("Failed converting signature")
+    return sig
+
+def ecdsa_recover(sig, msghash, context=_secp.ctx):
+    if len(sig)!=65:
+        raise ValueError("Recoverable signature should be 65 bytes long")
+    if len(msghash)!=32:
+        raise ValueError("Message should be 32 bytes long")
+    pub = bytes(64)
+    r = _secp.secp256k1_ecdsa_recover(context, pub, sig, msghash)
+    if r == 0:
+        raise ValueError("Failed converting signature")
+    return pub
+
+# Schnorr stuff
 if schnorr_available:
     def xonly_pubkey_parse(x, context=_secp.ctx):
         if len(x)!=32:


### PR DESCRIPTION
Requires secp256k1 with a flag
`./configure --enable-module-recovery`

`core/recovery.py` contains all the functions required for message signing and working with recoverable signatures
`core/recovery_test.py` shows an example of signing, parsing and pubkey recovery