### PR TITLE
Read and write protection

### DIFF
--- a/core/bl_syscalls.h
+++ b/core/bl_syscalls.h
@@ -203,6 +203,13 @@ bool blsys_flash_write_protect(bl_addr_t addr, size_t size, bool enable);
 bool blsys_flash_read_protect(int level);
 
 /**
+ * Returns current level of the read protection for the whole chip
+ *
+ * @return  protection level (platform dependent), or -1 if not available
+ */
+int blsys_flash_get_read_protection_level(void);
+
+/**
  * Returns a number of media devices searched for upgrade files
  *
  * The bootloader uses returned value to scan all available devices sequentially

--- a/core/bl_syscalls.h
+++ b/core/bl_syscalls.h
@@ -174,6 +174,35 @@ bool blsys_flash_write(bl_addr_t addr, const void* buf, size_t len);
 bool blsys_flash_crc32(uint32_t* p_crc, bl_addr_t addr, size_t len);
 
 /**
+ * Enables or disables write protection of flash memory
+ *
+ * This function does nothing if requested write protection state is unchanged,
+ * simply returning true.
+ *
+ * @param addr    starting address of erased area
+ * @param size    size of erased area
+ * @param enable  protection state:
+ *                  * true - write protection is enabled
+ *                  * false - write protection is disabled
+ * @return        true if successful
+ */
+bool blsys_flash_write_protect(bl_addr_t addr, size_t size, bool enable);
+
+/**
+ * Enables read protection for the whole chip
+ *
+ * Typically this function is called when a preprocessor macro, READ_PROTECTION
+ * is defined, passing value of this macro as an argument.
+ *
+ * This function does nothing if requested read protection level is unchanged,
+ * simply returning true.
+ *
+ * @param level  protection level (platform dependent)
+ * @return       true if successful
+ */
+bool blsys_flash_read_protect(int level);
+
+/**
  * Returns a number of media devices searched for upgrade files
  *
  * The bootloader uses returned value to scan all available devices sequentially

--- a/core/bl_syscalls_weak.c
+++ b/core/bl_syscalls_weak.c
@@ -96,6 +96,8 @@ WEAK bool blsys_flash_write_protect(bl_addr_t addr, size_t size, bool enable) {
 
 WEAK bool blsys_flash_read_protect(int level) { return true; }
 
+WEAK int blsys_flash_get_read_protection_level(void) { return -1; };
+
 WEAK uint32_t blsys_media_devices(void) { return 1U; }
 
 WEAK const char* blsys_media_name(uint32_t device_idx) {

--- a/core/bl_syscalls_weak.c
+++ b/core/bl_syscalls_weak.c
@@ -26,7 +26,7 @@
 
 /// Inert flash memory map
 const bl_addr_t bl_flash_map[bl_flash_map_nitems] WEAK = {
-    [bl_flash_firmware_base] = BL_ADDR_MAX}; // Marker of inert table
+    [bl_flash_firmware_base] = BL_ADDR_MAX};  // Marker of inert table
 
 WEAK const char* blsys_platform_id(void) {
   static const char* platform_id_ = PLATFORM_ID;
@@ -89,6 +89,12 @@ WEAK bool blsys_flash_crc32(uint32_t* p_crc, bl_addr_t addr, size_t len) {
   }
   return false;
 }
+
+WEAK bool blsys_flash_write_protect(bl_addr_t addr, size_t size, bool enable) {
+  return true;
+}
+
+WEAK bool blsys_flash_read_protect(int level) { return true; }
 
 WEAK uint32_t blsys_media_devices(void) { return 1U; }
 

--- a/core/bl_util.c
+++ b/core/bl_util.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdarg.h>
 #include "bl_util.h"
 
 /// Number of decimal digits in the XML version tag
@@ -47,14 +48,34 @@ bool bl_memveq(const void* ptr, int value, size_t num) {
   return false;
 }
 
-bool bl_strcat_checked(char *dst, size_t dst_size, const char *src) {
-  if(dst && src && dst_size > 1U) {
+bool bl_strcat_checked(char* dst, size_t dst_size, const char* src) {
+  if (dst && src && dst_size > 1U) {
     size_t dst_len = strlen(dst);
     size_t src_len = strlen(src);
-    if(dst_len + src_len + 1U <= dst_size) {
+    if (dst_len + src_len + 1U <= dst_size) {
       // Copy src string after dst string including terminating null-character
       memcpy(dst + dst_len, src, src_len + 1U);
       return true;
+    }
+  }
+  return false;
+}
+
+// TODO: test
+bool bl_format_append(char* dst_buf, size_t dst_size, const char* format, ...) {
+  if (dst_buf && dst_size && format) {
+    size_t str_len = strlen(dst_buf);
+    if (str_len < dst_size) {
+      va_list args;
+      va_start(args, format);
+      int out_len =
+          vsnprintf(dst_buf + str_len, dst_size - str_len, format, args);
+      va_end(args);
+      if(out_len > 0) {
+        return true;
+      }
+      // Restore original string's termination before returning false
+      dst_buf[str_len] = '\0';
     }
   }
   return false;

--- a/core/bl_util.h
+++ b/core/bl_util.h
@@ -118,11 +118,22 @@ static inline bool bl_streq(const char* stra, const char* strb) {
  * destination buffer.
  *
  * @param dst       destination buffer containing 1-st null-terminated string
- * @param dst_size  size of destination buffer in bytes
+ * @param dst_size  size of the destination buffer in bytes
  * @param src       buffer containing 2-nd null-terminated string
  * @return          true if successful
  */
 bool bl_strcat_checked(char *dst, size_t dst_size, const char *src);
+
+/**
+ * Appends formatted data to a string
+ *
+ * @param dst_buf   destination buffer containing a null-terminated string
+ * @param dst_size  size of the destination buffer in bytes
+ * @param format    null-terminated format string
+ * @param ...       list of arguments
+ * @return          true if successful
+ */
+bool bl_format_append(char* dst_buf, size_t dst_size, const char* format, ...);
 
 /**
  * Sets callback function which is called to report progress of operations

--- a/platforms/stm32f469disco/bootloader/Makefile
+++ b/platforms/stm32f469disco/bootloader/Makefile
@@ -107,6 +107,10 @@ ifneq ($(READ_PROTECTION),)
 C_DEFS += READ_PROTECTION=$(READ_PROTECTION)
 endif
 
+ifneq ($(WRITE_PROTECTION),)
+C_DEFS += WRITE_PROTECTION=$(WRITE_PROTECTION)
+endif
+
 # ASM sources
 ASM_SOURCES = $(shell find $(LOC_ROOT) -name *.s)
 

--- a/platforms/stm32f469disco/bootloader/Makefile
+++ b/platforms/stm32f469disco/bootloader/Makefile
@@ -95,14 +95,17 @@ C_INCLUDES =  \
 
 # C defines
 C_DEFS =  \
--DPLATFORM_ID=\"$(TARGET_PLATFORM)\" \
--DUSE_HAL_DRIVER \
--DSTM32F469xx \
--DHAVE_CONFIG_H \
--DSECP256K1_BUILD \
--D__BYTE_ORDER=1234 \
--DCRC32_USE_LOOKUP_TABLE_SLICING_BY_8 \
--Wno-unused-function
+PLATFORM_ID=\"$(TARGET_PLATFORM)\" \
+USE_HAL_DRIVER \
+STM32F469xx \
+HAVE_CONFIG_H \
+SECP256K1_BUILD \
+__BYTE_ORDER=1234 \
+CRC32_USE_LOOKUP_TABLE_SLICING_BY_8 \
+
+ifneq ($(READ_PROTECTION),)
+C_DEFS += READ_PROTECTION=$(READ_PROTECTION)
+endif
 
 # ASM sources
 ASM_SOURCES = $(shell find $(LOC_ROOT) -name *.s)
@@ -117,8 +120,9 @@ AS_DEFS =
 # binaries
 #######################################
 PREFIX = arm-none-eabi-
-# The gcc compiler bin path can be either defined in make command via GCC_PATH variable (> make GCC_PATH=xxx)
-# either it can be added to the PATH environment variable.
+# The gcc compiler bin path can be either defined in make command via GCC_PATH
+# variable (> make GCC_PATH=xxx) either it can be added to the PATH environment
+# variable.
 ifdef GCC_PATH
 CC = $(GCC_PATH)/$(PREFIX)gcc
 AS = $(GCC_PATH)/$(PREFIX)gcc -x assembler-with-cpp
@@ -151,9 +155,11 @@ FLOAT-ABI = -mfloat-abi=hard
 MCU = $(CPU) -mthumb $(FPU) $(FLOAT-ABI)
 
 # compile gcc flags
-ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+ASFLAGS = $(MCU) $(addprefix -D,$(AS_DEFS)) $(AS_INCLUDES) $(OPT) \
+-Wall -fdata-sections -ffunction-sections
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+CFLAGS = $(MCU) $(addprefix -D,$(C_DEFS)) $(C_INCLUDES) $(OPT) \
+-Wall -Wno-unused-function -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2 -DDEBUG=1
@@ -177,7 +183,8 @@ LDSCRIPTS = $(addprefix -T,$(LDSCRIPT_LST))
 # libraries
 LIBS = -lc -lm -lnosys
 LIBDIR =
-LDFLAGS = $(MCU) -specs=nano.specs $(LDSCRIPTS) $(LIBDIR) $(LIBS) -Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections -N
+LDFLAGS = $(MCU) -specs=nano.specs $(LDSCRIPTS) $(LIBDIR) $(LIBS) \
+-Wl,-Map=$(BUILD_DIR)/$(TARGET).map,--cref -Wl,--gc-sections -N
 
 # default action: build all
 all: $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex

--- a/platforms/stm32f469disco/common/linker_vars.h
+++ b/platforms/stm32f469disco/common/linker_vars.h
@@ -51,5 +51,9 @@ LV_EXTERN char _bl_copy2_start;
 LV_EXTERN char _bl_image_base;
 /// Mailbox used to pass parameters to the Bootloader
 LV_EXTERN char _startup_mailbox;
+/// Start of the Start-up code
+LV_EXTERN char _startup_code_start;
+/// Size of the Start-up code
+LV_EXTERN char _startup_code_size;
 
 #endif  // LINKER_VARS_H_INCLUDED

--- a/platforms/stm32f469disco/common/memory_map.ld
+++ b/platforms/stm32f469disco/common/memory_map.ld
@@ -61,3 +61,7 @@ _bl_copy2_start = ORIGIN(FLASH_BL2);
 _bl_image_base = _bl_copy1_start;
 /* Mailbox used to pass parameters to the Bootloader */
 _startup_mailbox = ORIGIN(RAM_MAILBOX);
+/* Start of the Start-up code */
+_startup_code_start = ORIGIN(FLASH_STARTUP);
+/* Size of the Start-up code */
+_startup_code_size = LENGTH(FLASH_STARTUP) + LENGTH(FLASH_STARTUP_VER);

--- a/platforms/stm32f469disco/startup/Makefile
+++ b/platforms/stm32f469disco/startup/Makefile
@@ -68,14 +68,13 @@ C_INCLUDES =  \
 
 # C defines
 C_DEFS =  \
--DPLATFORM_ID=\"$(TARGET_PLATFORM)\" \
--DUSE_HAL_DRIVER \
--DSTM32F469xx \
--DHAVE_CONFIG_H \
--D__BYTE_ORDER=1234 \
--DCRC32_USE_LOOKUP_TABLE_SLICING_BY_4 \
--DBL_NO_FATFS \
--Wno-unused-function
+PLATFORM_ID=\"$(TARGET_PLATFORM)\" \
+USE_HAL_DRIVER \
+STM32F469xx \
+HAVE_CONFIG_H \
+__BYTE_ORDER=1234 \
+CRC32_USE_LOOKUP_TABLE_SLICING_BY_4 \
+BL_NO_FATFS \
 
 # ASM sources
 ASM_SOURCES = $(shell find $(LOC_ROOT) -name *.s)
@@ -124,9 +123,11 @@ FLOAT-ABI = -mfloat-abi=hard
 MCU = $(CPU) -mthumb $(FPU) $(FLOAT-ABI)
 
 # compile gcc flags
-ASFLAGS = $(MCU) $(AS_DEFS) $(AS_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+ASFLAGS = $(MCU) $(addprefix -D,$(AS_DEFS)) $(AS_INCLUDES) $(OPT) \
+-Wall -fdata-sections -ffunction-sections
 
-CFLAGS = $(MCU) $(C_DEFS) $(C_INCLUDES) $(OPT) -Wall -fdata-sections -ffunction-sections
+CFLAGS = $(MCU) $(addprefix -D,$(C_DEFS)) $(C_INCLUDES) $(OPT) \
+-Wall -Wno-unused-function -fdata-sections -ffunction-sections
 
 ifeq ($(DEBUG), 1)
 CFLAGS += -g -gdwarf-2 -DDEBUG=1

--- a/platforms/testbench/bootloader/Makefile
+++ b/platforms/testbench/bootloader/Makefile
@@ -68,6 +68,10 @@ ifneq ($(READ_PROTECTION),)
 C_DEFS += READ_PROTECTION=$(READ_PROTECTION)
 endif
 
+ifneq ($(WRITE_PROTECTION),)
+C_DEFS += WRITE_PROTECTION=$(WRITE_PROTECTION)
+endif
+
 OBJS := $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
 

--- a/platforms/testbench/bootloader/Makefile
+++ b/platforms/testbench/bootloader/Makefile
@@ -57,23 +57,27 @@ C_INCLUDES =  \
 
 # C defines
 C_DEFS =  \
--DTESTBENCH_PROGRESS_NEWLINE \
--DBL_NO_FATFS \
--DHAVE_CONFIG_H \
--DSECP256K1_BUILD \
--D__BYTE_ORDER=1234 \
--DCRC32_USE_LOOKUP_TABLE_SLICING_BY_8 \
--Wno-unused-function
+TESTBENCH_PROGRESS_NEWLINE \
+BL_NO_FATFS \
+HAVE_CONFIG_H \
+SECP256K1_BUILD \
+__BYTE_ORDER=1234 \
+CRC32_USE_LOOKUP_TABLE_SLICING_BY_8 \
+
+ifneq ($(READ_PROTECTION),)
+C_DEFS += READ_PROTECTION=$(READ_PROTECTION)
+endif
 
 OBJS := $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
 
 DEPS := $(OBJS:.o=.d)
 
-CFLAGS = $(C_INCLUDES) -MMD -MP -Werror $(C_DEFS)
+CFLAGS = $(C_INCLUDES) -MMD -MP -Werror -Wno-unused-function \
+$(addprefix -D,$(C_DEFS))
 
 ifeq ($(DEBUG), 1)
-CFLAGS += -g
+CFLAGS += -g -DDEBUG=1
 LDFLAGS += -g
 endif
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -57,13 +57,12 @@ C_INCLUDES =  \
 
 # C defines
 C_DEFS =  \
--DUNIT_TEST \
--DBL_NO_FATFS \
--DHAVE_CONFIG_H \
--DSECP256K1_BUILD \
--D__BYTE_ORDER=1234 \
--DCRC32_USE_LOOKUP_TABLE_SLICING_BY_8 \
--Wno-unused-function
+UNIT_TEST \
+BL_NO_FATFS \
+HAVE_CONFIG_H \
+SECP256K1_BUILD \
+__BYTE_ORDER=1234 \
+CRC32_USE_LOOKUP_TABLE_SLICING_BY_8 \
 
 OBJS = $(addprefix $(BUILD_DIR)/,$(notdir $(C_SOURCES:.c=.o)))
 vpath %.c $(sort $(dir $(C_SOURCES)))
@@ -73,12 +72,14 @@ vpath %.cpp $(sort $(dir $(CPP_SOURCES)))
 
 DEPS := $(OBJS:.o=.d)
 
-CFLAGS = $(C_INCLUDES) -MMD -MP -Werror $(C_DEFS)
+CFLAGS = $(C_INCLUDES) -MMD -MP -Werror -Wno-unused-function \
+$(addprefix -D,$(C_DEFS))
+
 CPPFLAGS = -std=c++14
 LDFLAGS ?= -lstdc++
 
 ifeq ($(DEBUG), 1)
-CFLAGS += -g
+CFLAGS += -g -DDEBUG=1
 LDFLAGS += -g
 endif
 


### PR DESCRIPTION
### Read and write protection for flash memory

These features are controlled through the **Make's** command line by adding corresponding variables:

- `READ_PROTECTION=0` - programs RDP Level 0 (has no practical use) 
- `READ_PROTECTION=1` - programs RDP Level 1 
- `READ_PROTECTION=2` - programs RDP Level 2 (blocked by default, see below)
- `WRITE_PROTECTION=1` - enables write protection for the Start-up code, Main Firmware, and the Bootloader itself

**IMPORTANT:** After changing these variables it is needed to clean the build directory before the next build:

```shell
make clean
```

### Read protection

The **stm32f469disco** platform supports three levels of read protection:

- RDP Level 0 - no protection at all
- RDP Level 1 - no external access to flash memory, JTAG/SWD can be used to erase the chip
- RDP Level 2  - JTAG/SWD is disabled completely, protection settings cannot be changed

For additional information please see the STM32F469xx Reference Manual.

To enable RDP Level 2 in addition to `READ_PROTECTION=2` it is needed to modify the source code manually as well. In the file `platforms/stm32f469disco/bootloader/bl_syscalls.c`, the block of code inside `#ifdef 0` should be made active.  
https://github.com/cryptoadvance/specter-bootloader/blob/33f4ee7184b461b002fee69b47832a9398908b19/platforms/stm32f469disco/bootloader/bl_syscalls.c#L749

**WARNING:** By enabling RDP Level 2 protection mode you are making an irreversible change to the flash memory of the MCU. It is not possible to use the board for debugging after running the Bootloader compiled with `READ_PROTECTION=2`. The Start-up code becomes unreplaceable as well. Also, note that RDP Level 2 in the Bootloader is not tested on the hardware yet. Use it at your own risk.

### Write protection 

When the write protection enabled with `WRITE_PROTECTION=1` the Bootloader applies the write protection to every sector of the flash memory it updates. The sector containing the Start-up code is write-protected as well.

When the Bootloader is about to update a flash memory sector it removes write-protection temporary. This feature works even if `WRITE_PROTECTION` is not enabled. In the latter case write protection is not restored after the update.