### PR TITLE
Downgrade protection improvement

### DIFF
--- a/core/bl_integrity_check.h
+++ b/core/bl_integrity_check.h
@@ -1,6 +1,6 @@
 /**
  * @file       bl_integrity_check.h
- * @brief      Bootloader integrity check functions
+ * @brief      Bootloader integrity and version check functions
  * @author     Mike Tolkachev <contact@miketolkachev.dev>
  * @copyright  Copyright 2020 Crypto Advance GmbH. All rights reserved.
  */
@@ -16,15 +16,35 @@
 #include "bl_util.h"
 #include "bl_syscalls.h"
 
-/// Size of integrity check record
-#define BL_ICR_SIZE 32U
-
 // The following types are private and defined only in implementation of
 // signature module and in unit tests.
 #ifdef BL_ICR_DEFINE_PRIVATE_TYPES
 
+/// Size of integrity check record
+#define BL_ICR_SIZE 32U
+/// Size of version check record
+#define BL_VCR_SIZE 32U
+/// Total overhead from all metadata stored together with firmware
+#define BL_FW_SECT_OVERHEAD (BL_ICR_SIZE + BL_VCR_SIZE)
+// Offset of ICR record from the end of firmware section
+#define BL_ICR_OFFSET_FROM_END (BL_ICR_SIZE + BL_VCR_SIZE)
+// Offset of VCR record from the end of firmware section
+#define BL_VCR_OFFSET_FROM_END (BL_VCR_SIZE)
+/// Magic word, "INTG" in LE
+#define BL_ICR_MAGIC 0x47544E49UL
+/// Magic string for version check record: 16 bytes with terminating '\0'
+#define BL_VCR_MAGIC "VERSIONCHECKREC"
+/// ICR: structure revision
+#define BL_ICR_STRUCT_REV 1U
+/// ICR: size of the part of integrity check record that is checked using CRC
+#define ICR_CRC_CHECKED_SIZE offsetof(bl_integrity_check_rec_t, struct_crc)
+/// VCR: structure revision
+#define BL_VCR_STRUCT_REV 1U
+/// VCR: size of the part of integrity check record that is checked using CRC
+#define VCR_CRC_CHECKED_SIZE offsetof(bl_version_check_rec_t, struct_crc)
+
 /// One section of integrity check record
-typedef struct __attribute__((packed)) bl_icr_sect_ {
+typedef struct BL_ATTRS((packed)) bl_icr_sect_ {
   uint32_t pl_size;  ///< Payload size
   uint32_t pl_crc;   ///< Payload CRC
 } bl_icr_sect_t;
@@ -34,7 +54,7 @@ typedef struct __attribute__((packed)) bl_icr_sect_ {
 /// This structure has fixed size of 32 bytes. All 32-bit words are stored in
 /// little-endian format. CRC is calculated over first 28 bytes byte of this
 /// structure.
-typedef struct __attribute__((packed)) bl_integrity_check_rec_ {
+typedef struct BL_ATTRS((packed)) bl_integrity_check_rec_ {
   uint32_t magic;           ///< Magic word, BL_ICR_MAGIC
   uint32_t struct_rev;      ///< Revision of structure format
   uint32_t pl_ver;          ///< Payload version, 0 if not available
@@ -43,7 +63,30 @@ typedef struct __attribute__((packed)) bl_integrity_check_rec_ {
   uint32_t struct_crc;      ///< CRC of this structure using LE representation
 } bl_integrity_check_rec_t;
 
+/// Version check record
+///
+/// This structure has fixed size of 32 bytes. All 32-bit words are stored in
+/// little-endian format. CRC is calculated over first 28 bytes byte of this
+/// structure.
+typedef struct BL_ATTRS((packed)) bl_version_check_rec_t_ {
+  char magic[sizeof(BL_VCR_MAGIC)];  ///< Magic string, BL_VCR_MAGIC
+  uint32_t struct_rev;               ///< Revision of structure format
+  uint32_t pl_ver;                   ///< Payload version, 0 if not available
+  uint32_t rsv[1];                   ///< Reserved word
+  uint32_t struct_crc;  ///< CRC of this structure using LE representation
+} bl_version_check_rec_t;
+
 #endif  // BL_ICR_DEFINE_PRIVATE_TYPES
+
+/// Place of a version check record inside the firmware section
+typedef enum bl_vcr_place_t_ {
+  /// At the beginning of the section
+  bl_vcr_starting = (1 << 0),
+  /// At the end of the section
+  bl_vcr_ending = (1 << 1),
+  /// At any valid place inside the section
+  bl_vcr_any = (int)bl_vcr_starting | (int)bl_vcr_ending,
+} bl_vcr_place_t;
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,7 +99,7 @@ extern "C" {
  * @param sect_size  full size of section in flash memory
  * @param pl_size    size of payload (firmware) stored in firmware section
  * @param pl_ver     version of payload (firmware)
- * @return           true if integrity check record successfully created
+ * @return           true if the integrity check record is successfully created
  */
 bool bl_icr_create(bl_addr_t sect_addr, uint32_t sect_size, uint32_t pl_size,
                    uint32_t pl_ver);
@@ -81,6 +124,41 @@ bool bl_icr_verify(bl_addr_t sect_addr, uint32_t sect_size, uint32_t* p_pl_ver);
  */
 bool bl_icr_get_version(bl_addr_t sect_addr, uint32_t sect_size,
                         uint32_t* p_pl_ver);
+
+/**
+ * Checks if flash memory section has enough space to store the payload
+ *
+ * @param sect_size  full size of section in flash memory
+ * @param pl_size    size of payload (firmware) stored in firmware section
+ * @return           true if the payload can be stored in the given section
+ */
+bool bl_icr_check_sect_size(uint32_t sect_size, uint32_t pl_size);
+
+/**
+ * Creates a version check record in the flash memory
+ *
+ * @param sect_addr  address of section in flash memory
+ * @param sect_size  full size of section in flash memory
+ * @param pl_ver     version of payload (firmware)
+ * @param place      place of a VCR record inside the firmware memory section
+ * @return           true if the version check record is successfully created
+ */
+bool bl_vcr_create(bl_addr_t sect_addr, uint32_t sect_size, uint32_t pl_ver,
+                   bl_vcr_place_t place);
+
+/**
+ * Reads the version check record and returns payload version from it
+ *
+ * If *bl_vcr_any* is passed as a *place* parameter, then the function looks
+ * through all records returning the latest available version.
+ *
+ * @param sect_addr  address of section in flash memory
+ * @param sect_size  full size of section in flash memory
+ * @param place      place of a VCR record inside the firmware section
+ * @return           payload version or BL_VERSION_NA if unsuccessful
+ */
+uint32_t bl_vcr_get_version(bl_addr_t sect_addr, uint32_t sect_size,
+                            bl_vcr_place_t place);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/core/bl_integrity_check.h
+++ b/core/bl_integrity_check.h
@@ -52,7 +52,7 @@ typedef struct BL_ATTRS((packed)) bl_icr_sect_ {
 /// Integrity check record
 ///
 /// This structure has fixed size of 32 bytes. All 32-bit words are stored in
-/// little-endian format. CRC is calculated over first 28 bytes byte of this
+/// little-endian format. CRC is calculated over first 28 bytes of this
 /// structure.
 typedef struct BL_ATTRS((packed)) bl_integrity_check_rec_ {
   uint32_t magic;           ///< Magic word, BL_ICR_MAGIC
@@ -66,7 +66,7 @@ typedef struct BL_ATTRS((packed)) bl_integrity_check_rec_ {
 /// Version check record
 ///
 /// This structure has fixed size of 32 bytes. All 32-bit words are stored in
-/// little-endian format. CRC is calculated over first 28 bytes byte of this
+/// little-endian format. CRC is calculated over first 28 bytes of this
 /// structure.
 typedef struct BL_ATTRS((packed)) bl_version_check_rec_t_ {
   char magic[sizeof(BL_VCR_MAGIC)];  ///< Magic string, BL_VCR_MAGIC

--- a/core/bl_syscalls.h
+++ b/core/bl_syscalls.h
@@ -58,6 +58,7 @@ typedef struct bl_ffind_ctx_struct {
 typedef enum bl_flash_map_item_t_ {
   bl_flash_firmware_base = 0,      ///< Base address of the Main Firmware
   bl_flash_firmware_size,          ///< Size reserved for the Main Firmware
+  bl_flash_firmware_part1_size,    ///< Size of Main Firmware's 1-st part
   bl_flash_bootloader_image_base,  ///< Base address of Bootloader in HEX file
   bl_flash_bootloader_copy1_base,  ///< Base address of Bootloader copy 1
   bl_flash_bootloader_copy2_base,  ///< Base address of Bootloader copy 2

--- a/core/bl_util.h
+++ b/core/bl_util.h
@@ -122,7 +122,7 @@ static inline bool bl_streq(const char* stra, const char* strb) {
  * @param src       buffer containing 2-nd null-terminated string
  * @return          true if successful
  */
-bool bl_strcat_checked(char *dst, size_t dst_size, const char *src);
+bool bl_strcat_checked(char* dst, size_t dst_size, const char* src);
 
 /**
  * Appends formatted data to a string
@@ -224,6 +224,29 @@ static inline bool bl_version_is_rc(uint32_t version) {
  */
 static inline void bl_keep_variable(volatile const void* ptr) {
   (void)*(volatile const char*)ptr;
+}
+
+/**
+ * Returns maximum of two uint32_t numbers
+ *
+ * @param a  1-st number
+ * @param b  2-nd number
+ * @return   maximum of (a,b)
+ */
+static inline uint32_t bl_max_u32(uint32_t a, uint32_t b) {
+  return (a > b) ? a : b;
+}
+
+/**
+ * Returns maximum of three uint32_t numbers
+ *
+ * @param a  1-st number
+ * @param b  2-nd number
+ * @param c  3-rd number
+ * @return   maximum of (a,b,c)
+ */
+static inline uint32_t bl_max3_u32(uint32_t a, uint32_t b, uint32_t c) {
+  return bl_max_u32(bl_max_u32(a, b), c);
 }
 
 #endif  // BL_UTIL_H_INCLUDED

--- a/core/bl_util.h
+++ b/core/bl_util.h
@@ -35,7 +35,7 @@
 
 /// Maximum allowed value ov version number
 #define BL_VERSION_MAX 4199999999U
-/// Version is not available
+/// Version is not available, guaranteed to be less than any valid version
 #define BL_VERSION_NA 0U
 /// Maximum size of version string including null character
 #define BL_VERSION_STR_MAX 16U

--- a/core/bootloader.c
+++ b/core/bootloader.c
@@ -587,7 +587,7 @@ static bool check_sect_compatibility(const bl_section_t* p_hdr,
       // Check parameters and attributes
       return bl_streq(platform, blsys_platform_id()) &&
              base_addr == sect_base &&
-             p_hdr->pl_size + BL_ICR_SIZE <= sect_size;
+             bl_icr_check_sect_size(sect_size, p_hdr->pl_size);
     }
   }
   return false;

--- a/core/bootloader.c
+++ b/core/bootloader.c
@@ -768,18 +768,18 @@ static bool erase_main_firmware_area(void) {
   uint32_t latest_ver = bl_max3_u32(icr_ver, startvcr_ver, endvcr_ver);
 
   bool ok = (fw_size > part1_size);
-  // Check if we have VCR at the beginning of the section (interrupted upgrade)
+  // (1) Check if we have VCR at the beginning of the section
   if (BL_VERSION_NA == startvcr_ver) {  // No VCR at the beginning
-    // (1) Erase part 1
+    // (2) Erase part 1
     ok = ok && blsys_flash_erase(fw_addr, part1_size);
-    // (2) Create VCR at the beginning of the section
+    // (3) Create VCR at the beginning of the section
     ok = ok && bl_vcr_create(fw_addr, fw_size, latest_ver, bl_vcr_starting);
   }
-  // (3) Erase part 2
+  // (4) Erase part 2
   ok = ok && blsys_flash_erase(fw_addr + part1_size, fw_size - part1_size);
-  // (4) Create VCR at the end of the section
+  // (5) Create VCR at the end of the section
   ok = ok && bl_vcr_create(fw_addr, fw_size, latest_ver, bl_vcr_ending);
-  // (5) Erase part 1
+  // (6) Erase part 1
   ok = ok && blsys_flash_erase(fw_addr, part1_size);
 
   return ok;

--- a/core/bootloader.c
+++ b/core/bootloader.c
@@ -47,8 +47,9 @@
 
 /// Flash memory map items
 typedef struct flash_map_t {
-  bl_addr_t firmware_base;          ///< Base address of [main] Firmware
-  bl_addr_t firmware_size;          ///< Size reserved for [main] Firmware
+  bl_addr_t firmware_base;          ///< Base address of the Main Firmware
+  bl_addr_t firmware_size;          ///< Size reserved for the Main Firmware
+  bl_addr_t firmware_part1_size;    ///< Size of Main Firmware's 1-st part
   bl_addr_t bootloader_image_base;  ///< Base address of Bootloader in HEX file
   bl_addr_t bootloader_copy1_base;  ///< Base address of Bootloader copy 1
   bl_addr_t bootloader_copy2_base;  ///< Base address of Bootloader copy 2
@@ -295,13 +296,16 @@ static bool sanity_check(void) {
 static inline bool get_flash_memory_map(flash_map_t* p_map) {
   if (p_map) {
     memset(p_map, 0, sizeof(flash_map_t));
-    return blsys_flash_map_get_items(
-        6, bl_flash_firmware_base, &p_map->firmware_base,
+    bool ok = blsys_flash_map_get_items(
+        7, bl_flash_firmware_base, &p_map->firmware_base,
         bl_flash_firmware_size, &p_map->firmware_size,
+        bl_flash_firmware_part1_size, &p_map->firmware_part1_size,
         bl_flash_bootloader_image_base, &p_map->bootloader_image_base,
         bl_flash_bootloader_copy1_base, &p_map->bootloader_copy1_base,
         bl_flash_bootloader_copy2_base, &p_map->bootloader_copy2_base,
         bl_flash_bootloader_size, &p_map->bootloader_size);
+    ok = ok && (p_map->firmware_part1_size < p_map->firmware_size);
+    return ok;
   }
   return false;
 }
@@ -656,16 +660,25 @@ static version_check_res_t check_version(uint32_t new_ver, uint32_t curr_ver,
 static version_check_res_t check_versions(const file_metadata_t* p_md,
                                           version_info_t curr, uint32_t flags) {
   if (p_md) {
+    // Check version of the Bootloader
     version_check_res_t check_bl =
         p_md->boot_section.loaded
             ? check_version(p_md->boot_section.header.pl_ver,
                             curr.bootloader_ver, flags)
             : version_same;
 
+    // Get saved version from version check record. It stores the latest
+    // version even if the Main firmware is erased.
+    uint32_t saved_ver =
+        bl_vcr_get_version(bl_ctx.flash_map.firmware_base,
+                           bl_ctx.flash_map.firmware_size, bl_vcr_any);
+    // Chose the latest version number of all sources: ICR & 2x VCR.
+    uint32_t latest_ver = bl_max_u32(curr.main_fw_ver, saved_ver);
+    // Check version of the Main Firmware from file against the latest version
+    // ever programmed in the device.
     version_check_res_t check_main =
         p_md->main_section.loaded
-            ? check_version(p_md->main_section.header.pl_ver, curr.main_fw_ver,
-                            flags)
+            ? check_version(p_md->main_section.header.pl_ver, latest_ver, flags)
             : version_same;
 
     // Return check result with the higher rank (severity in case of error)
@@ -738,6 +751,41 @@ static bool verify_payload_sections(bl_file_t file,
 }
 
 /**
+ * Erases the Main Firmware area of the flash memory preserving the VCR
+ *
+ * @return  true if successful
+ */
+static bool erase_main_firmware_area(void) {
+  bl_addr_t fw_addr = bl_ctx.flash_map.firmware_base;
+  bl_addr_t fw_size = bl_ctx.flash_map.firmware_size;
+  bl_addr_t part1_size = bl_ctx.flash_map.firmware_part1_size;
+
+  // Chose the latest version number of all sources: ICR & 2x VCR
+  uint32_t icr_ver = BL_VERSION_NA;
+  (void)bl_icr_get_version(fw_addr, fw_size, &icr_ver);
+  uint32_t startvcr_ver = bl_vcr_get_version(fw_addr, fw_size, bl_vcr_starting);
+  uint32_t endvcr_ver = bl_vcr_get_version(fw_addr, fw_size, bl_vcr_ending);
+  uint32_t latest_ver = bl_max3_u32(icr_ver, startvcr_ver, endvcr_ver);
+
+  bool ok = (fw_size > part1_size);
+  // Check if we have VCR at the beginning of the section (interrupted upgrade)
+  if (BL_VERSION_NA == startvcr_ver) {  // No VCR at the beginning
+    // (1) Erase part 1
+    ok = ok && blsys_flash_erase(fw_addr, part1_size);
+    // (2) Create VCR at the beginning of the section
+    ok = ok && bl_vcr_create(fw_addr, fw_size, latest_ver, bl_vcr_starting);
+  }
+  // (3) Erase part 2
+  ok = ok && blsys_flash_erase(fw_addr + part1_size, fw_size - part1_size);
+  // (4) Create VCR at the end of the section
+  ok = ok && bl_vcr_create(fw_addr, fw_size, latest_ver, bl_vcr_ending);
+  // (5) Erase part 1
+  ok = ok && blsys_flash_erase(fw_addr, part1_size);
+
+  return ok;
+}
+
+/**
  * Erases sections of the flash memory preparing for an upgrade
  *
  * @param p_md     pointer to upgrade file metadata
@@ -756,8 +804,7 @@ static bool erase_flash(const file_metadata_t* p_md, bl_addr_t bl_addr) {
     }
     if (p_md->main_section.loaded) {
       bl_report_progress(stage_erase_flash | substage_main, 1U, 0U);
-      if (!blsys_flash_erase(bl_ctx.flash_map.firmware_base,
-                             bl_ctx.flash_map.firmware_size)) {
+      if (!erase_main_firmware_area()) {
         return false;
       }
       bl_report_progress(stage_erase_flash | substage_main, 1U, 1U);

--- a/platforms/stm32f469disco/bootloader/bl_syscalls.c
+++ b/platforms/stm32f469disco/bootloader/bl_syscalls.c
@@ -112,6 +112,7 @@ static const flash_layout_t flash_layout[] = {
 const bl_addr_t bl_flash_map[bl_flash_map_nitems] = {
   [bl_flash_firmware_base]         = LV_VALUE(_main_firmware_start),
   [bl_flash_firmware_size]         = LV_VALUE(_main_firmware_size),
+  [bl_flash_firmware_part1_size]   = LV_VALUE(_main_firmware_part1_size),
   [bl_flash_bootloader_image_base] = LV_VALUE(_bl_image_base),
   [bl_flash_bootloader_copy1_base] = LV_VALUE(_bl_copy1_start),
   [bl_flash_bootloader_copy2_base] = LV_VALUE(_bl_copy2_start),

--- a/platforms/stm32f469disco/common/linker_vars.h
+++ b/platforms/stm32f469disco/common/linker_vars.h
@@ -41,6 +41,8 @@ LV_EXTERN char _ram_code_start;
 LV_EXTERN char _main_firmware_start;
 /// Size of the Main Firmware
 LV_EXTERN char _main_firmware_size;
+/// Size of the Main Firmware's 1-st part
+LV_EXTERN char _main_firmware_part1_size;
 /// Size of flash memory sector where the Bootloader is stored
 LV_EXTERN char _bl_sect_size;
 /// Start of the Bootloader copy 1, stored in the flash memory

--- a/platforms/stm32f469disco/common/memory_map.ld
+++ b/platforms/stm32f469disco/common/memory_map.ld
@@ -53,6 +53,8 @@ _flash_code_start = ORIGIN(FLASH_BL1);
 _main_firmware_start = ORIGIN(FLASH_MAIN_FW);
 /* Size of the Main Firmware */
 _main_firmware_size = LENGTH(FLASH_MAIN_FW);
+/* Size of the Main Firmware's 1-st part: sector 5 */
+_main_firmware_part1_size = 128K;
 /* Start of the Bootloader copy 1, stored in Flash memory */
 _bl_copy1_start = ORIGIN(FLASH_BL1);
 /* Start of the Bootloader copy 2, stored in Flash memory */

--- a/test/flash_buf.hpp
+++ b/test/flash_buf.hpp
@@ -48,12 +48,19 @@ class FlashBuf {
   }
 
   inline operator uint8_t*() const { return flash_emu_buf; }
-  inline uint8_t& operator[](int index) { return flash_emu_buf[index]; }
+  inline uint8_t& operator[](int index) {
+    if (index >= 0 && index < flash_emu_size) {
+      return flash_emu_buf[index];
+    }
+    INFO("ERROR: indexing outside flash emulation buffer");
+    REQUIRE(false);  // Abort test
+    return flash_emu_buf[0]; // Formal
+  }
   inline bl_addr_t base() { return flash_emu_base; }
   inline bl_addr_t size() { return flash_emu_size; }
   inline bl_addr_t pl_size() { return pl_size_; }
 
-private:
+ private:
   uint32_t pl_size_;
 };
 

--- a/tools/core/integritychk.py
+++ b/tools/core/integritychk.py
@@ -12,7 +12,13 @@ _BL_ICR_MAGIC = 0x47544E49
 # Structure revision
 _STRUCT_REV = 1
 # Size of integrity check record
-BL_ICR_SIZE = 32
+_BL_ICR_SIZE = 32
+# Size of version check record
+_BL_VCR_SIZE = 32
+# Total overhead from all metadata stored together with firmware
+BL_FW_SECT_OVERHEAD = (_BL_ICR_SIZE+_BL_VCR_SIZE)
+# Offset of ICR record from the end of firmware section
+BL_ICR_OFFSET_FROM_END = (_BL_ICR_SIZE+_BL_VCR_SIZE)
 
 
 class _bl_icr_sect_t(LittleEndianStructure):

--- a/tools/make-initial-firmware.py
+++ b/tools/make-initial-firmware.py
@@ -82,11 +82,11 @@ def combine(out_file, startup_hex, bootloader_hex, firmware_hex, bin_out):
 
     # Write resulting firmware in HEX or binary format
     if bin_out:
-      file_obj = open(out_file, "wb")
-      file_obj.write(intelhex_to_bytes(out_ih))
-      file_obj.close()
+        file_obj = open(out_file, "wb")
+        file_obj.write(intelhex_to_bytes(out_ih))
+        file_obj.close()
     else:
-      out_ih.write_hex_file(out_file)
+        out_ih.write_hex_file(out_file)
 
 
 def intelhex_to_bytes(ih_obj):
@@ -123,11 +123,12 @@ def intelhex_add_icr(ih_obj, storage_size):
         raise TypeError("Storage object should be IntelHex")
 
     data_len = ih_obj.maxaddr() - ih_obj.minaddr() + 1
-    if data_len > MAX_PAYLOAD_SIZE or data_len + BL_ICR_SIZE > storage_size:
+    if (data_len > MAX_PAYLOAD_SIZE or
+            data_len + BL_FW_SECT_OVERHEAD > storage_size):
         raise click.ClickException(f"Error while parsing '{hex_file.name}'")
 
     icr = icr_create(intelhex_to_bytes(ih_obj))
-    addr = ih_obj.minaddr() + storage_size - BL_ICR_SIZE
+    addr = ih_obj.minaddr() + storage_size - BL_ICR_OFFSET_FROM_END
     intelhex_add_data(ih_obj, addr, icr)
 
 


### PR DESCRIPTION
This adds robust downgrade protection, operating even when the Main Firmware is erased.

The new version check record contains the latest version that was ever programmed in the device. This record is created and updated when the Main Firmware section of the flash memory is erased. For more information, please see the updated spec:

https://github.com/cryptoadvance/specter-bootloader/blob/downgrade_protection_improvement/doc/bootloader-spec.md#version-check-record