### PR TITLE
Fix blank screen after displaying version on a clean device

### DIFF
--- a/platforms/stm32f469disco/bootloader/gui.c
+++ b/platforms/stm32f469disco/bootloader/gui.c
@@ -151,6 +151,7 @@ static void lcd_init_if_needed(void) {
     // Turn the display on
     HAL_Delay(100);
     BSP_LCD_DisplayOn();
+    ctx.displayed_page = gui_page_none;
     ctx.lcd_initialized = true;
   }
 }


### PR DESCRIPTION
When the ".show_version" file is found on a microSD card, the device with no Main Firmware displays a blank screen after the version information screen. This PR fixes this issue by de-selecting the currently displayed GUI page at reinitialization.