### PR TITLE
fix: bump bootloader version to 1.0.2 for key rotation

### DIFF
--- a/platforms/stm32f469disco/bootloader/main.c
+++ b/platforms/stm32f469disco/bootloader/main.c
@@ -26,7 +26,7 @@ typedef enum upy_reset_mode_t {
 
 /// Version in the format parced by upgrade-generator
 static const char version_tag[] BL_ATTRS((used)) =
-    "<version:tag10>0100000199</version:tag10>";
+    "<version:tag10>0100000299</version:tag10>";
 
 /// Embedded memory map record
 // clang-format off


### PR DESCRIPTION
## Summary

- Bumps bootloader version tag from 1.0.1 (`0100000199`) to 1.0.2 (`0100000299`)
- Fixes the v1.10.0 → v1.10.1 upgrade failure ("Not enough signatures")

## Problem

The startup code selects between two bootloader copies based on the ICR version — highest wins, ties go to copy 1. When v1.10.0 writes the new bootloader (with rotated signing keys) to the inactive slot, both copies end up at version 1.0.1. The startup code keeps running copy 1 (old keys), so v1.10.1 signed with the new keys fails signature verification.

Full analysis: https://github.com/cryptoadvance/specter-diy/issues/330#issuecomment-4106030562

## Test plan

- [ ] Rebuild bootloader with this change
- [ ] Regenerate v1.10.0 upgrade binary with the new bootloader
- [ ] Verify upgrade path: v1.9.0 → v1.10.0 → v1.10.1 via SD card
- [ ] Confirm "Bootloader: 1.0.1 → 1.0.2" on upgrade complete screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)